### PR TITLE
Fix random test failure

### DIFF
--- a/animatplot/animation.py
+++ b/animatplot/animation.py
@@ -64,12 +64,15 @@ class Animation:
             self.timeline._update()
             return updates
 
-        return FuncAnimation(
-            self.fig,
-            update_all,
-            frames=self.timeline._len,
-            interval=1000 / self.timeline.fps,
-        )
+        # For some reason this can fail with a keyerror, however
+        # printing something before hand resolves that. Thus just
+        # retrying resolves the issue.
+        args = self.fig, update_all
+        kwargs = dict(frames=self.timeline._len, interval=1000 / self.timeline.fps)
+        try:
+            return FuncAnimation(*args, **kwargs)
+        except KeyError:
+            return FuncAnimation(*args, **kwargs)
 
     @property
     def _controls_gridspec(self):

--- a/animatplot/blocks/lineplots.py
+++ b/animatplot/blocks/lineplots.py
@@ -44,7 +44,6 @@ class Line(Block):
     """
 
     def __init__(self, *args, ax=None, t_axis=0, **kwargs):
-
         super().__init__(ax, t_axis)
 
         if len(args) == 1:

--- a/animatplot/blocks/title.py
+++ b/animatplot/blocks/title.py
@@ -38,7 +38,6 @@ class Title(Block):
         super().__init__(ax)
 
         if isinstance(text, str):
-
             # Filter out only the keyword args which are things to be replaced
             # in the title text
             # Parsing trick from https://stackoverflow.com/questions/25996937/

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -66,7 +66,6 @@ def animation_compare(baseline_images, nframes, fmt=".png", tol=1e-3, remove_tex
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-
             # First close anything from previous tests
             plt.close("all")
 


### PR DESCRIPTION
Full error output:

```
============================= test session starts ==============================
platform linux -- Python 3.12.0b3, pytest-7.3.2, pluggy-1.0.0
rootdir: /builddir/build/BUILD/animatplot-ng-0.4.3
collected 41 items
tests/test_animation.py x.....F...                                       [ 24%]
tests/test_blocks.py ..............ss...........                         [ 90%]
tests/test_timeline.py ..                                                [ 95%]
tests/test_util.py ..                                                    [100%]
=================================== FAILURES ===================================
____________________ TestAddAnimations.test_add_animations _____________________
self = <tests.test_animation.TestAddAnimations object at 0xd3eb9240>
line_anim = <function line_anim.<locals>.make_line_anim at 0xd13c9208>
    def test_add_animations(self, line_anim):
>       anim = line_anim()
tests/test_animation.py:132: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/test_animation.py:79: in make_line_anim
    anim = amp.Animation([block])
animatplot/animation.py:36: in __init__
    self.animation = self._animate(blocks, timeline)
animatplot/animation.py:70: in _animate
    return FuncAnimation(
/usr/lib/python3.12/site-packages/matplotlib/animation.py:1694: in __init__
    super().__init__(fig, **kwargs)
/usr/lib/python3.12/site-packages/matplotlib/animation.py:1416: in __init__
    super().__init__(fig, event_source=event_source, *args, **kwargs)
/usr/lib/python3.12/site-packages/matplotlib/animation.py:873: in __init__
    self._first_draw_id = fig.canvas.mpl_connect('draw_event', self._start)
/usr/lib/python3.12/site-packages/matplotlib/backend_bases.py:2476: in mpl_connect
    return self.callbacks.connect(s, func)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <matplotlib.cbook.CallbackRegistry object at 0xd145c6c0>
signal = 'draw_event'
func = <bound method Animation._start of <matplotlib.animation.FuncAnimation object at 0xd13cc7b0>>
    def connect(self, signal, func):
        """Register *func* to be called when signal *signal* is generated."""
        if self._signals is not None:
            _api.check_in_list(self._signals, signal=signal)
        self._func_cid_map.setdefault(signal, {})
        proxy = _weak_or_strong_ref(func, self._remove_proxy)
>       if proxy in self._func_cid_map[signal]:
E       KeyError: 'draw_event'
/usr/lib/python3.12/site-packages/matplotlib/cbook/__init__.py:230: KeyError
```